### PR TITLE
Move fields from dataset to variable level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ pythonpath = ["src/datadoc_editor"]
 [tool.uv]
 required-version = ">=0.6.17"
 
+[tool.uv.sources]
+dapla-toolbelt-metadata = { git = "https://github.com/statisticsnorway/dapla-toolbelt-metadata.git", rev = "49e7bea" }
+
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]
 tests = ["tests", "*/tests"]

--- a/src/datadoc_editor/frontend/fields/display_dataset.py
+++ b/src/datadoc_editor/frontend/fields/display_dataset.py
@@ -12,7 +12,6 @@ from datadoc_editor import state
 from datadoc_editor.enums import Assessment
 from datadoc_editor.enums import DataSetState
 from datadoc_editor.enums import DataSetStatus
-from datadoc_editor.enums import TemporalityTypeType
 from datadoc_editor.enums import UseRestriction
 from datadoc_editor.frontend.fields.display_base import DATASET_METADATA_DATE_INPUT
 from datadoc_editor.frontend.fields.display_base import (
@@ -20,14 +19,12 @@ from datadoc_editor.frontend.fields.display_base import (
 )
 from datadoc_editor.frontend.fields.display_base import DROPDOWN_DESELECT_OPTION
 from datadoc_editor.frontend.fields.display_base import FieldTypes
-from datadoc_editor.frontend.fields.display_base import MetadataCheckboxField
 from datadoc_editor.frontend.fields.display_base import MetadataDateField
 from datadoc_editor.frontend.fields.display_base import MetadataDropdownField
 from datadoc_editor.frontend.fields.display_base import MetadataInputField
 from datadoc_editor.frontend.fields.display_base import MetadataMultiLanguageField
 from datadoc_editor.frontend.fields.display_base import MetadataPeriodField
 from datadoc_editor.frontend.fields.display_base import get_comma_separated_string
-from datadoc_editor.frontend.fields.display_base import get_data_source_options
 from datadoc_editor.frontend.fields.display_base import get_enum_options
 
 logger = logging.getLogger(__name__)
@@ -42,19 +39,6 @@ def get_statistical_subject_options() -> list[dict[str, str]]:
         }
         for primary in state.statistic_subject_mapping.primary_subjects
         for secondary in primary.secondary_subjects
-    ]
-    dropdown_options.insert(0, {"title": DROPDOWN_DESELECT_OPTION, "id": ""})
-    return dropdown_options
-
-
-def get_unit_type_options() -> list[dict[str, str]]:
-    """Collect the unit type options."""
-    dropdown_options = [
-        {
-            "title": unit_type.get_title(enums.SupportedLanguages.NORSK_BOKMÅL),
-            "id": unit_type.code,
-        }
-        for unit_type in state.unit_types.classifications
     ]
     dropdown_options.insert(0, {"title": DROPDOWN_DESELECT_OPTION, "id": ""})
     return dropdown_options
@@ -82,16 +66,12 @@ class DatasetIdentifiers(str, Enum):
     DATASET_STATE = "dataset_state"
     NAME = "name"
     DESCRIPTION = "description"
-    DATA_SOURCE = "data_source"
     POPULATION_DESCRIPTION = "population_description"
     VERSION = "version"
     VERSION_DESCRIPTION = "version_description"
-    UNIT_TYPE = "unit_type"
-    TEMPORALITY_TYPE = "temporality_type"
     SUBJECT_FIELD = "subject_field"
     KEYWORD = "keyword"
     SPATIAL_COVERAGE_DESCRIPTION = "spatial_coverage_description"
-    CONTAINS_PERSONAL_DATA = "contains_personal_data"
     USE_RESTRICTION = "use_restriction"
     USE_RESTRICTION_DATE = "use_restriction_date"
     ID = "id"
@@ -115,12 +95,6 @@ DISPLAY_DATASET: dict[
         description="Oppgi navn på datasettet. Navnet skal være forståelig for mennesker slik at det er søkbart.",
         obligatory=True,
         id_type=DATASET_METADATA_MULTILANGUAGE_INPUT,
-    ),
-    DatasetIdentifiers.CONTAINS_PERSONAL_DATA: MetadataCheckboxField(
-        identifier=DatasetIdentifiers.CONTAINS_PERSONAL_DATA.value,
-        display_name="Inneholder personopplysninger",
-        description="Oppgi om datasettet inneholder personopplysninger. All informasjon som entydig kan knyttes til en fysisk person (f.eks. fødselsnummer og adresse), er personopplysninger. Pseudonymiserte personopplysninger er fortsatt personopplysninger. Næringsdata om enkeltpersonforetak (ENK) skal imidlertid ikke regnes som personopplysninger.",
-        obligatory=True,
     ),
     DatasetIdentifiers.DESCRIPTION: MetadataMultiLanguageField(
         identifier=DatasetIdentifiers.DESCRIPTION.value,
@@ -180,13 +154,6 @@ DISPLAY_DATASET: dict[
         ),
         obligatory=True,
     ),
-    DatasetIdentifiers.UNIT_TYPE: MetadataDropdownField(
-        identifier=DatasetIdentifiers.UNIT_TYPE.value,
-        display_name="Enhetstype",
-        description="Den eller de enhetstypen(e) datasettet inneholder informasjon om. Eksempler på enhetstyper er person, foretak og eiendom.",
-        options_getter=get_unit_type_options,
-        obligatory=True,
-    ),
     DatasetIdentifiers.CONTAINS_DATA_FROM: MetadataPeriodField(
         identifier=DatasetIdentifiers.CONTAINS_DATA_FROM.value,
         display_name="Inneholder data f.o.m.",
@@ -202,23 +169,6 @@ DISPLAY_DATASET: dict[
         obligatory=True,
         editable=True,
         id_type=DATASET_METADATA_DATE_INPUT,
-    ),
-    DatasetIdentifiers.DATA_SOURCE: MetadataDropdownField(
-        identifier=DatasetIdentifiers.DATA_SOURCE.value,
-        display_name="Datakilde",
-        description="Oppgi kilden til datasettet (på etat-/organisasjonsnivå). Dersom flere variabler i datasettet har ulik datakilde, kan disse dokumenteres på variabelnivå.",
-        obligatory=True,
-        options_getter=get_data_source_options,
-    ),
-    DatasetIdentifiers.TEMPORALITY_TYPE: MetadataDropdownField(
-        identifier=DatasetIdentifiers.TEMPORALITY_TYPE.value,
-        display_name="Temporalitetstype",
-        description="Temporalitetstypen sier noe om tidsdimensjonen i datasettet. Fast er data med verdi som ikke endres over tid (f.eks. fødselsdato), tverrsnitt er data som er målt på et gitt tidspunkt, akkumulert er data som er samlet over en viss tidsperiode (f.eks. inntekt gjennom et år) og hendelse/forløp registrerer tidspunkt og tidsperiode for ulike hendelser /tilstander, f.eks. (skifte av) bosted.",
-        options_getter=functools.partial(
-            get_enum_options,
-            TemporalityTypeType,
-        ),
-        obligatory=True,
     ),
     DatasetIdentifiers.SUBJECT_FIELD: MetadataDropdownField(
         identifier=DatasetIdentifiers.SUBJECT_FIELD.value,

--- a/src/datadoc_editor/frontend/fields/display_variables.py
+++ b/src/datadoc_editor/frontend/fields/display_variables.py
@@ -84,20 +84,20 @@ DISPLAY_VARIABLES: dict[
     VariableIdentifiers.NAME: MetadataMultiLanguageField(
         identifier=VariableIdentifiers.NAME.value,
         display_name="Navn",
-        description="Variabelnavn som er forståelig for mennesker. Navnet kan arves fra  lenket VarDef-variabel eller endres her (ev. oppgis her i tilfeller der variabelen ikke skal lenkes til VarDef).",
+        description="Variabelnavn som er forståelig for mennesker. Navnet kan arves fra lenket Vardef-variabel eller endres her (ev. oppgis her i tilfeller der variabelen ikke skal lenkes til Vardef).",
         obligatory=True,
         id_type=VARIABLES_METADATA_MULTILANGUAGE_INPUT,
     ),
     VariableIdentifiers.DEFINITION_URI: MetadataInputField(
         identifier=VariableIdentifiers.DEFINITION_URI.value,
         display_name="Definition URI",
-        description="Oppgi lenke (URI) til tilhørende variabel i VarDef.",
+        description="Oppgi lenke (URI) til tilhørende variabel i Vardef.",
         obligatory=False,
     ),
     VariableIdentifiers.COMMENT: MetadataMultiLanguageField(
         identifier=VariableIdentifiers.COMMENT.value,
         display_name="Kommentar",
-        description="Kommentaren har to funksjoner. Den skal brukes til å beskrive variabelforekomsten dersom denne ikke har lenke til VarDef (gjelder klargjorte data, statistikk og utdata), og den kan brukes til å gi ytterligere presiseringer av variabelforekomstens definisjon dersom variabelforekomsten er lenket til VarDef",
+        description="Kommentaren har to funksjoner. Den skal brukes til å beskrive variabelforekomsten dersom denne ikke har lenke til Vardef (gjelder klargjorte data, statistikk og utdata), og den kan brukes til å gi ytterligere presiseringer av variabelforekomstens definisjon dersom variabelforekomsten er lenket til Vardef",
         id_type=VARIABLES_METADATA_MULTILANGUAGE_INPUT,
     ),
     VariableIdentifiers.IS_PERSONAL_DATA: MetadataCheckboxField(
@@ -109,7 +109,7 @@ DISPLAY_VARIABLES: dict[
     VariableIdentifiers.UNIT_TYPE: MetadataDropdownField(
         identifier=VariableIdentifiers.UNIT_TYPE.value,
         display_name="Enhetstype",
-        description="Den eller de enhetstypen(e) datasettet inneholder informasjon om. Eksempler på enhetstyper er person, foretak og eiendom.",
+        description="Den enhetstypen variabelen inneholder informasjon om. Eksempler på enhetstyper er person, foretak og eiendom.",
         options_getter=get_unit_type_options,
         obligatory=True,
     ),
@@ -155,13 +155,13 @@ DISPLAY_VARIABLES: dict[
     VariableIdentifiers.DATA_SOURCE: MetadataDropdownField(
         identifier=VariableIdentifiers.DATA_SOURCE.value,
         display_name="Datakilde",
-        description="Oppgi datakilden til variabelen (på etat-/organisasjonsnivå) dersom denne ikke allerede er satt på  datasettnivå. Brukes hovedsakelig når variabler i et datasett har ulike datakilder.",
+        description="Datakilden til variabelen (på etat-/organisasjonsnivå).",
         options_getter=get_data_source_options,
     ),
     VariableIdentifiers.TEMPORALITY_TYPE: MetadataDropdownField(
         identifier=VariableIdentifiers.TEMPORALITY_TYPE.value,
         display_name="Temporalitetstype",
-        description="Temporalitetstypen settes vanligvis på datasettnivå, men dersom datasettet består av variabler med ulike temporalitetstyper, kan den settes på variabelnivå. Temporalitet sier noe om tidsdimensjonen i datasettet. Fast er data med verdi som ikke endres over tid (f.eks. fødselsdato), tverrsnitt er data som er målt på et gitt tidspunkt, akkumulert er data som  er samlet over en viss tidsperiode (f.eks. inntekt gjennom et år) og  hendelse/forløp registrerer tidspunkt og tidsperiode for ulike hendelser /tilstander, f.eks. (skifte av) bosted.",
+        description="Temporalitet sier noe om tidsdimensjonen for variabelen. Fast er data med verdi som ikke endres over tid (f.eks. fødselsdato), tverrsnitt er data som er målt på et gitt tidspunkt, akkumulert er data som  er samlet over en viss tidsperiode (f.eks. inntekt gjennom et år) og  hendelse/forløp registrerer tidspunkt og tidsperiode for ulike hendelser /tilstander, f.eks. (skifte av) bosted.",
         options_getter=functools.partial(
             get_enum_options,
             TemporalityTypeType,

--- a/src/datadoc_editor/frontend/fields/display_variables.py
+++ b/src/datadoc_editor/frontend/fields/display_variables.py
@@ -11,6 +11,7 @@ from datadoc_editor import state
 from datadoc_editor.enums import DataType
 from datadoc_editor.enums import TemporalityTypeType
 from datadoc_editor.enums import VariableRole
+from datadoc_editor.frontend.fields.display_base import DROPDOWN_DESELECT_OPTION
 from datadoc_editor.frontend.fields.display_base import VARIABLES_METADATA_DATE_INPUT
 from datadoc_editor.frontend.fields.display_base import (
     VARIABLES_METADATA_MULTILANGUAGE_INPUT,
@@ -38,6 +39,19 @@ def get_measurement_unit_options() -> list[dict[str, str]]:
     return dropdown_options
 
 
+def get_unit_type_options() -> list[dict[str, str]]:
+    """Collect the unit type options."""
+    dropdown_options = [
+        {
+            "title": unit_type.get_title(enums.SupportedLanguages.NORSK_BOKMÅL),
+            "id": unit_type.code,
+        }
+        for unit_type in state.unit_types.classifications
+    ]
+    dropdown_options.insert(0, {"title": DROPDOWN_DESELECT_OPTION, "id": ""})
+    return dropdown_options
+
+
 class VariableIdentifiers(str, Enum):
     """As defined here: https://statistics-norway.atlassian.net/wiki/spaces/MPD/pages/3042869256/Variabelforekomst."""
 
@@ -47,6 +61,7 @@ class VariableIdentifiers(str, Enum):
     VARIABLE_ROLE = "variable_role"
     DEFINITION_URI = "definition_uri"
     IS_PERSONAL_DATA = "is_personal_data"
+    UNIT_TYPE = "unit_type"
     DATA_SOURCE = "data_source"
     POPULATION_DESCRIPTION = "population_description"
     COMMENT = "comment"
@@ -89,6 +104,13 @@ DISPLAY_VARIABLES: dict[
         identifier=VariableIdentifiers.IS_PERSONAL_DATA.value,
         display_name="Er personopplysning",
         description="Dersom variabelen er en personopplysning, skal denne sjekkboksen være avkrysset. Dersom den ikke er en personopplysning, lar en bare defaultsvaret bli stående. All informasjon som entydig kan knyttes til en fysisk person (f.eks. fødselsnummer eller adresse) er personopplysninger. Næringsdata om enkeltpersonforetak (ENK) skal imidlertid ikke regnes som personopplysninger.",
+        obligatory=True,
+    ),
+    VariableIdentifiers.UNIT_TYPE: MetadataDropdownField(
+        identifier=VariableIdentifiers.UNIT_TYPE.value,
+        display_name="Enhetstype",
+        description="Den eller de enhetstypen(e) datasettet inneholder informasjon om. Eksempler på enhetstyper er person, foretak og eiendom.",
+        options_getter=get_unit_type_options,
         obligatory=True,
     ),
     VariableIdentifiers.POPULATION_DESCRIPTION: MetadataMultiLanguageField(

--- a/tests/frontend/callbacks/test_dataset_callbacks.py
+++ b/tests/frontend/callbacks/test_dataset_callbacks.py
@@ -97,11 +97,6 @@ def file_path_without_dates():
             ),
         ),
         (
-            DatasetIdentifiers.DATA_SOURCE,
-            "Census",
-            "Census",
-        ),
-        (
             DatasetIdentifiers.POPULATION_DESCRIPTION,
             "Population description",
             model.LanguageStringType(
@@ -125,16 +120,6 @@ def file_path_without_dates():
                     ),
                 ],
             ),
-        ),
-        (
-            DatasetIdentifiers.UNIT_TYPE,
-            "17",
-            "17",
-        ),
-        (
-            DatasetIdentifiers.TEMPORALITY_TYPE,
-            enums.TemporalityTypeType.ACCUMULATED,
-            enums.TemporalityTypeType.ACCUMULATED.value,
         ),
         (
             DatasetIdentifiers.SUBJECT_FIELD,
@@ -166,7 +151,6 @@ def file_path_without_dates():
                 ],
             ),
         ),
-        (DatasetIdentifiers.CONTAINS_PERSONAL_DATA, True, True),
         (
             DatasetIdentifiers.USE_RESTRICTION,
             enums.UseRestriction.PROCESS_LIMITATIONS,

--- a/tests/frontend/callbacks/test_variables_callbacks.py
+++ b/tests/frontend/callbacks/test_variables_callbacks.py
@@ -93,6 +93,11 @@ def n_clicks_1():
             False,
         ),
         (
+            VariableIdentifiers.UNIT_TYPE,
+            "17",
+            "17",
+        ),
+        (
             VariableIdentifiers.DATA_SOURCE,
             "Atlantis",
             "Atlantis",
@@ -339,16 +344,6 @@ def test_populate_variables_workspace_filter_variables(
     ),
     [
         (
-            "STATUS",
-            DatasetIdentifiers.TEMPORALITY_TYPE,
-            VariableIdentifiers.TEMPORALITY_TYPE,
-        ),
-        (
-            "01",
-            DatasetIdentifiers.DATA_SOURCE,
-            VariableIdentifiers.DATA_SOURCE,
-        ),
-        (
             "2009-01-02",
             DatasetIdentifiers.CONTAINS_DATA_FROM,
             VariableIdentifiers.CONTAINS_DATA_FROM,
@@ -391,18 +386,6 @@ def test_variables_values_inherit_dataset_values(
         "update_value",
     ),
     [
-        (
-            "EVENT",
-            DatasetIdentifiers.TEMPORALITY_TYPE,
-            VariableIdentifiers.TEMPORALITY_TYPE,
-            "ACCUMULATED",
-        ),
-        (
-            "02",
-            DatasetIdentifiers.DATA_SOURCE,
-            VariableIdentifiers.DATA_SOURCE,
-            "03",
-        ),
         (
             "2009-01-02",
             DatasetIdentifiers.CONTAINS_DATA_FROM,

--- a/tests/frontend/components/test_build_dataset_edit_section.py
+++ b/tests/frontend/components/test_build_dataset_edit_section.py
@@ -23,7 +23,6 @@ NON_ATYPICAL_DROPDOWNS = [
     if m.editable
     and m.identifier
     not in (
-        DatasetIdentifiers.UNIT_TYPE.value,
         DatasetIdentifiers.SUBJECT_FIELD.value,
         DatasetIdentifiers.OWNER.value,
     )
@@ -99,7 +98,7 @@ def test_build_dataset_section_is_html_section(
                 {"type": "dataset-edit-section", "id": "dataset-nb"},
             ),
             6,
-            13,
+            9,
         ),
     ],
 )

--- a/tests/frontend/fields/test_display_dataset.py
+++ b/tests/frontend/fields/test_display_dataset.py
@@ -5,8 +5,6 @@ from datadoc_editor.frontend.fields.display_base import DROPDOWN_DESELECT_OPTION
 from datadoc_editor.frontend.fields.display_dataset import (
     get_statistical_subject_options,
 )
-from datadoc_editor.frontend.fields.display_dataset import get_unit_type_options
-from tests.conftest import CODE_LIST_DIR
 from tests.conftest import STATISTICAL_SUBJECT_STRUCTURE_DIR
 from tests.utils import TEST_RESOURCES_DIRECTORY
 
@@ -47,26 +45,3 @@ def test_get_statistical_subject_options(
     state.statistic_subject_mapping = subject_mapping_fake_statistical_structure
     state.statistic_subject_mapping.wait_for_external_result()
     assert get_statistical_subject_options() == expected
-
-
-@pytest.mark.parametrize(
-    ("code_list_csv_filepath_nb", "expected"),
-    [
-        (
-            TEST_RESOURCES_DIRECTORY / CODE_LIST_DIR / "code_list_nb.csv",
-            [
-                {"title": DROPDOWN_DESELECT_OPTION, "id": ""},
-                {"title": "Adresse", "id": "01"},
-                {"title": "Arbeidsulykke", "id": "02"},
-                {"title": "Bolig", "id": "03"},
-            ],
-        ),
-    ],
-)
-def test_get_unit_type_options(
-    code_list_fake_structure,
-    expected,
-):
-    state.unit_types = code_list_fake_structure
-    state.unit_types.wait_for_external_result()
-    assert get_unit_type_options() == expected

--- a/tests/frontend/fields/test_display_variables.py
+++ b/tests/frontend/fields/test_display_variables.py
@@ -1,0 +1,30 @@
+import pytest
+
+from datadoc_editor import state
+from datadoc_editor.frontend.fields.display_base import DROPDOWN_DESELECT_OPTION
+from datadoc_editor.frontend.fields.display_variables import get_unit_type_options
+from tests.conftest import CODE_LIST_DIR
+from tests.utils import TEST_RESOURCES_DIRECTORY
+
+
+@pytest.mark.parametrize(
+    ("code_list_csv_filepath_nb", "expected"),
+    [
+        (
+            TEST_RESOURCES_DIRECTORY / CODE_LIST_DIR / "code_list_nb.csv",
+            [
+                {"title": DROPDOWN_DESELECT_OPTION, "id": ""},
+                {"title": "Adresse", "id": "01"},
+                {"title": "Arbeidsulykke", "id": "02"},
+                {"title": "Bolig", "id": "03"},
+            ],
+        ),
+    ],
+)
+def test_get_unit_type_options(
+    code_list_fake_structure,
+    expected,
+):
+    state.unit_types = code_list_fake_structure
+    state.unit_types.wait_for_external_result()
+    assert get_unit_type_options() == expected

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version < '3.13'",
@@ -253,8 +253,8 @@ wheels = [
 
 [[package]]
 name = "dapla-toolbelt-metadata"
-version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.8.5"
+source = { git = "https://github.com/statisticsnorway/dapla-toolbelt-metadata.git?rev=49e7bea#49e7bea3209157da05ef37fd8a11b0ea274364d3" }
 dependencies = [
     { name = "arrow" },
     { name = "beautifulsoup4" },
@@ -270,10 +270,6 @@ dependencies = [
     { name = "ssb-datadoc-model" },
     { name = "ssb-klass-python" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/3f/3e90701e79c7f7106aff6e3d67c1a6f635b54953e1d8cd9f8372559c67e9/dapla_toolbelt_metadata-0.8.0.tar.gz", hash = "sha256:a6baa8744d372d831a6f809b50f6e2000c4076069bae5f6a69b1da1f873392ad", size = 95685, upload-time = "2025-06-10T07:11:55.551Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/58/bb96630de068d0a7efd383bb85ccb5bc6adeae4247157978ea461182b0f4/dapla_toolbelt_metadata-0.8.0-py3-none-any.whl", hash = "sha256:a408ee534d3ecea02d09b9d7b9fcbcf41f1e28f1b41feb9eb8f5537691c58795", size = 171497, upload-time = "2025-06-10T07:11:53.655Z" },
 ]
 
 [[package]]
@@ -2048,7 +2044,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "arrow", specifier = ">=1.3.0" },
-    { name = "dapla-toolbelt-metadata", specifier = ">=0.8.0" },
+    { name = "dapla-toolbelt-metadata", git = "https://github.com/statisticsnorway/dapla-toolbelt-metadata.git?rev=49e7bea" },
     { name = "dash", specifier = ">=2.15.0" },
     { name = "dash-bootstrap-components", specifier = ">=1.1.0" },
     { name = "flask-healthz", specifier = ">=0.0.3" },
@@ -2092,14 +2088,10 @@ dev = [
 
 [[package]]
 name = "ssb-datadoc-model"
-version = "7.0.1"
-source = { registry = "https://pypi.org/simple" }
+version = "7.0.2"
+source = { git = "https://github.com/statisticsnorway/ssb-datadoc-model.git?subdirectory=generated%2Fpython%2Fdatadoc_model&rev=676b3e7#676b3e73b1843392e8763e8ef86c5589daffccff" }
 dependencies = [
     { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/6a/3927508823df3d4fe59932b52a89d97a74aa8c8b3a1ac7270f8aa1362c8f/ssb_datadoc_model-7.0.1.tar.gz", hash = "sha256:e01a3097d5d96e7507a52da7c384dffa99ff553d2fdcc5477207f6a94cb38bbc", size = 28743, upload-time = "2025-05-28T11:14:34.093Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/20/ea3571837b6da2e9b237dc8a8e0f58fa7a11426eb099ede0917972478dc3/ssb_datadoc_model-7.0.1-py3-none-any.whl", hash = "sha256:8495285da6d641855281d018fb5f207464f61227d655ad1e7281569843ace6f0", size = 11289, upload-time = "2025-05-28T11:14:32.789Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Remove from dataset:
   - data_source
   - unit_type
   - temporality_type
   - contains_personal_data
 - Add to variables:
   - unit_type
 - Fix descriptions

⚠️ This depends on a git version of dapla-toolbelt-metadata package in order to incrementally integrate changes. This needs to be fixed before release.