### PR TITLE
Variables sections show globally updated variables

### DIFF
--- a/src/datadoc_editor/frontend/callbacks/variables_callbacks.py
+++ b/src/datadoc_editor/frontend/callbacks/variables_callbacks.py
@@ -21,6 +21,7 @@ from datadoc_editor.frontend.callbacks.variables import (
 from datadoc_editor.frontend.callbacks.variables import accept_variable_metadata_input
 from datadoc_editor.frontend.callbacks.variables import populate_variables_workspace
 from datadoc_editor.frontend.components.identifiers import ACCORDION_WRAPPER_ID
+from datadoc_editor.frontend.components.identifiers import GLOBAL_ADDED_VARIABLES_STORE
 from datadoc_editor.frontend.components.identifiers import VARIABLES_INFORMATION_ID
 from datadoc_editor.frontend.fields.display_base import VARIABLES_METADATA_DATE_INPUT
 from datadoc_editor.frontend.fields.display_base import VARIABLES_METADATA_INPUT
@@ -46,11 +47,13 @@ def register_variables_callbacks(app: Dash) -> None:
         Input("dataset-opened-counter", "data"),
         Input("search-variables", "value"),
         Input("metadata-save-counter", "data"),
+        Input(GLOBAL_ADDED_VARIABLES_STORE, "data"),
     )
     def callback_populate_variables_workspace(
         dataset_opened_counter: int,
         search_query: str,
         metadata_save_counter: int,  # noqa: ARG001
+        added_variables_store: dict,  # noqa: ARG001 we want values to be shown for each variable when they are changed globally
     ) -> list:
         """Create variable workspace with accordions for variables."""
         logger.debug("Populating variables workspace. Search query: %s", search_query)


### PR DESCRIPTION
In keeping with the principle of least surprise and Datadoc-editor being a "What You See Is What You Get" editor, we should keep the UI up-to-date with the underlying values. This will make it easier for users to know what metadata will be saved and for them to override values for specific variables if they need.

<img width="1882" height="917" alt="Screenshot 2025-10-08 at 09 34 53" src="https://github.com/user-attachments/assets/2d286406-6d1a-460c-96fa-c80e6a9ec133" />
