### PR TITLE
Keep global accordion open when editing

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -13,14 +13,14 @@ package = "datadoc_editor"
 python_versions = ["3.12", "3.13", "3.14"]
 nox.needs_version = ">= 2021.6.6"
 nox.options.default_venv_backend = "uv"
-nox.options.sessions = (
+nox.options.sessions = [
     "pre-commit",
     "mypy",
     "tests",
     "typeguard",
     "xdoctest",
     "docs-build",
-)
+]
 
 
 def install_with_uv(

--- a/src/datadoc_editor/frontend/callbacks/global_variables_callbacks.py
+++ b/src/datadoc_editor/frontend/callbacks/global_variables_callbacks.py
@@ -50,18 +50,22 @@ def register_global_variables_callbacks(app: Dash) -> None:
     @app.callback(
         Output(GLOBAL_VARIABLES_ID, "children"),
         Input("dataset-opened-counter", "data"),
-        Input(GLOBAL_VARIABLES_VALUES_STORE, "data"),
+        State(GLOBAL_VARIABLES_VALUES_STORE, "data"),
     )
     def callback_populate_variables_globals_section(
         dataset_opened_counter: int,  # noqa: ARG001
         store_data,  # noqa: ANN001
     ) -> None | ssb.Accordion:
-        """Populating global variables section."""
+        """Populating global variables section.
+
+        Only rebuilt when a new dataset is opened, so the accordion keeps its
+        open state while the user edits fields.
+        """
         if state.metadata.variables and len(state.metadata.variables) > 0:
             return build_global_ssb_accordion(
                 header=GLOBAL_HEADER,
                 key={"id": "global_id", "type": "accordion"},
-                children=build_global_edit_section(GLOBAL_VARIABLES, store_data),
+                children=build_global_edit_section(GLOBAL_VARIABLES, store_data or {}),
             )
         return None
 


### PR DESCRIPTION
There was a bug which fired a callback at every edit in global variables accordion (and closed the accordion before user had registered changes).
This fix makes sure the section does not rebuild at every edit, just once when dataset is opened. 
User can now close the accordion when ready.

Also:
- Latest version of nox requires a list of sessions, not tuple
